### PR TITLE
fix issue with multisite dropdown menu in admin 

### DIFF
--- a/plugins/themes/journals-home/JournalsHomeThemePlugin.inc.php
+++ b/plugins/themes/journals-home/JournalsHomeThemePlugin.inc.php
@@ -12,6 +12,7 @@ class JournalsHomeThemePlugin extends ThemePlugin {
 	public function init() {
 		$this->setParent('defaultthemeplugin');
 		$this->addStyle('custom', 'styles/custom.less');
+    $this->addStyle('custom-backend', 'styles/backend.less', array( 'contexts' => 'backend' ));
 	}
 
 	/**

--- a/plugins/themes/journals-home/styles/backend.less
+++ b/plugins/themes/journals-home/styles/backend.less
@@ -1,0 +1,4 @@
+.pkpDropdown__content {
+  columns: 3;
+  max-width: 100vw;
+}


### PR DESCRIPTION
There are too many journals to fit in the editorial backend's multisite dropdown menu. Adding these custom styles to the Journals home theme will transform the dropdown to a full-browser menu which displays all sites. 
